### PR TITLE
Notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         include:
           - platform: 'macos-latest'
-            args: '--target aarch64-apple-darwin --bundles dmg'
+            args: '--target aarch64-apple-darwin --bundles app'
             arch: 'aarch64'
           - platform: 'macos-latest' 
-            args: '--target x86_64-apple-darwin --bundles dmg'
+            args: '--target x86_64-apple-darwin --bundles app'
             arch: 'x86_64'
 
     runs-on: ${{ matrix.platform }}
@@ -65,9 +65,9 @@ jobs:
 
             ### Installation Notes
 
-            **macOS**: Download the `.dmg` file for your architecture:
-            - `presto_x.x.x_aarch64.dmg` for Apple Silicon (M1/M2/M3 Macs)
-            - `presto_x.x.x_x64.dmg` for Intel Macs
+            **macOS**: Download the `.app` file for your architecture:
+            - `presto_x.x.x_aarch64.app.tar.gz` for Apple Silicon (M1/M2/M3 Macs)
+            - `presto_x.x.x_x64.app.tar.gz` for Intel Macs
 
             ### Auto-Updates
 

--- a/generate-keys.sh
+++ b/generate-keys.sh
@@ -5,22 +5,28 @@
 
 echo "🔐 Generating update signing keys for Tauri..."
 
-# Verifica se tauri CLI è disponibile
-if ! command -v tauri &> /dev/null; then
-    echo "❌ Tauri CLI not found. Please install it first:"
-    echo "npm install --save-dev @tauri-apps/cli@latest"
+# Verifica se npm è disponibile
+if ! command -v npm &> /dev/null; then
+    echo "❌ npm not found. Please install Node.js first."
     exit 1
+fi
+
+# Controlla se è stata passata l'opzione --force
+FORCE_OPTION=""
+if [[ "$@" == *"--force"* ]]; then
+    FORCE_OPTION="--force"
+    echo "⚠️ Force option detected. Will overwrite existing keys."
 fi
 
 # Genera le chiavi di firma
 echo "📝 Generating signing keypair..."
-tauri signer generate -w ~/.tauri/tempo_signing_key
+npx tauri signer generate -w ~/.tauri/tempo_signing_key $FORCE_OPTION
 
 if [ $? -eq 0 ]; then
     echo "✅ Keys generated successfully!"
     echo ""
     echo "🔑 Your public key is:"
-    tauri signer sign -k ~/.tauri/tempo_signing_key --password "" | head -1
+    npx tauri signer sign -k ~/.tauri/tempo_signing_key --password "" | head -1
     echo ""
     echo "📋 Next steps:"
     echo "1. Copy the public key above"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "presto",
-  "version": "0.2.4",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "presto",
-      "version": "0.2.4",
+      "version": "0.2.9",
       "dependencies": {
         "@aptabase/tauri": "^0.4.1",
         "@tauri-apps/api": "^2.5.0",

--- a/release.sh
+++ b/release.sh
@@ -175,7 +175,8 @@ update_homebrew_tap() {
 # Funzione per fare la build
 build_app() {
     print_step "Avvio build dell'applicazione..."
-    npm run build
+    # Modifica per utilizzare bundles app invece di dmg
+    npm run tauri build -- --bundles app
     print_success "Build completata"
 }
 
@@ -312,7 +313,7 @@ main() {
     # Mostra informazioni sui file generati
     if [[ -d "src-tauri/target" ]]; then
         echo "File di build generati:"
-        find src-tauri/target -name "*.dmg" -o -name "*.app" -o -name "*.deb" -o -name "*.AppImage" 2>/dev/null | head -5
+        find src-tauri/target -name "*.app.tar.gz" -o -name "*.app" -o -name "*.deb" -o -name "*.AppImage" 2>/dev/null | head -5
     fi
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,39 +24,23 @@
     }
   },
   "bundle": {
-    "createUpdaterArtifacts": true,
+    "active": true,
     "targets": [
-      "dmg",
       "app"
     ],
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ],
-    "macOS": {
-      "dmg": {
-        "appPosition": {
-          "x": 180,
-          "y": 170
-        },
-        "applicationFolderPosition": {
-          "x": 480,
-          "y": 170
-        },
-        "windowSize": {
-          "width": 660,
-          "height": 400
-        }
-      }
-    }
+    ]
   },
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://api.github.com/repos/murdercode/presto/releases/latest"
+        "https://github.com/murdercode/presto/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENCNDYxMDAyQjIxQkM4MjAKUldRZ3lCdXlBaEJHeXp3bnRHYWRwOVM2WFo1T3IzMXJWUnlJYUtwWlEzcnBKVHpnaXpJNjhmK1gK",
       "dangerousInsecureTransportProtocol": false

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -58,7 +58,7 @@
       "endpoints": [
         "https://api.github.com/repos/murdercode/presto/releases/latest"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIwQTUwNDBBQkRENTBDQjgKUldT\nNEROVzlDZ1Nsc0Q4eExoSG5jbjE1N1ppLzZRYUFvUUNqR1VYQmJFaEpvcFpjV3c4VDljSHoK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENCNDYxMDAyQjIxQkM4MjAKUldRZ3lCdXlBaEJHeXp3bnRHYWRwOVM2WFo1T3IzMXJWUnlJYUtwWlEzcnBKVHpnaXpJNjhmK1gK",
       "dangerousInsecureTransportProtocol": false
     }
   }

--- a/src/core/pomodoro-timer.js
+++ b/src/core/pomodoro-timer.js
@@ -548,7 +548,9 @@ export class PomodoroTimer {
 
             this.updateButtons();
             this.updateDisplay();
-            NotificationUtils.playNotificationSound();
+            if (this.enableSoundNotifications) {
+                NotificationUtils.playNotificationSound();
+            }
             NotificationUtils.showNotificationPing('Timer started! 🍅', 'info', this.currentMode);
 
             // Start smart pause monitoring if enabled
@@ -846,7 +848,9 @@ export class PomodoroTimer {
         await this.saveSessionData();
         await this.updateWeeklyStats();
         this.showNotification();
-        NotificationUtils.playNotificationSound();
+        if (this.enableSoundNotifications) {
+            NotificationUtils.playNotificationSound();
+        }
 
         // Show completion message
         let completionMessage;
@@ -940,7 +944,9 @@ export class PomodoroTimer {
 
         // Show notification
         this.showNotification();
-        NotificationUtils.playNotificationSound();
+        if (this.enableSoundNotifications) {
+            NotificationUtils.playNotificationSound();
+        }
 
         // Show completion message for continuous sessions
         const continuousMessages = {

--- a/src/utils/theme-loader.js
+++ b/src/utils/theme-loader.js
@@ -39,7 +39,7 @@ class ThemeLoader {
         // that gets updated by the build process or manually maintained
 
         // This could be enhanced to use a build-time script that generates this list
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                const knownThemes = [
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        const knownThemes = [
             'espresso.css',
             'matrix.css',
             'pommodore64.css'


### PR DESCRIPTION
This pull request introduces several changes across the workflow configuration, build scripts, application bundling, and the Pomodoro timer functionality. The key updates include switching macOS builds from `.dmg` to `.app` bundles, enhancing the `generate-keys.sh` script, modifying the Tauri configuration, and adding sound notifications to the Pomodoro timer.

### Workflow and Build Updates:
* Updated `.github/workflows/release.yml` to replace `.dmg` bundles with `.app` bundles for macOS builds, and adjusted the installation notes accordingly. (`[[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-R25)`, `[[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L68-R70)`)
* Modified `release.sh` to use `.app` bundles instead of `.dmg` in the build process and updated the file search logic to reflect the new `.app.tar.gz` format. (`[[1]](diffhunk://#diff-8bc94a3006768345d17c827c0bb5840e6e4daee6de1c2b1ea672f53f162d171dL178-R179)`, `[[2]](diffhunk://#diff-8bc94a3006768345d17c827c0bb5840e6e4daee6de1c2b1ea672f53f162d171dL315-R316)`)

### Script Enhancements:
* Enhanced `generate-keys.sh` to check for `npm` instead of `tauri`, added a `--force` option for overwriting existing keys, and switched to using `npx` for Tauri commands. (`[generate-keys.shL8-R29](diffhunk://#diff-2eb804a20bbae507cc1e484a7cb6856e0fd343af91808bd8856be1f96423d8cfL8-R29)`)

### Tauri Configuration Changes:
* Updated `tauri.conf.json` to use `.app` bundles as the primary target, removed `.dmg` configurations, and updated the updater endpoint and public key. (`[src-tauri/tauri.conf.jsonL27-R45](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L27-R45)`)

### Application Functionality:
* Added sound notifications to the `PomodoroTimer` class, triggered when the timer starts, completes a session, or displays a notification. (`[[1]](diffhunk://#diff-7bbc05e66d2a3fff640f1b3b02dd208154540f6ae6270128fc2b40831e23a98dR551-R553)`, `[[2]](diffhunk://#diff-7bbc05e66d2a3fff640f1b3b02dd208154540f6ae6270128fc2b40831e23a98dR851-R853)`, `[[3]](diffhunk://#diff-7bbc05e66d2a3fff640f1b3b02dd208154540f6ae6270128fc2b40831e23a98dR947-R949)`)