### PR TITLE
Feature 5plusmins

### DIFF
--- a/src/core/pomodoro-timer.js
+++ b/src/core/pomodoro-timer.js
@@ -65,6 +65,8 @@ export class PomodoroTimer {
         this.smartPauseCountdown = document.getElementById('smart-pause-countdown');
         this.autoStartIndicator = document.getElementById('auto-start-indicator');
         this.continuousSessionIndicator = document.getElementById('continuous-session-indicator');
+        this.timerPlusBtn = document.getElementById('timer-plus-btn');
+        this.timerMinusBtn = document.getElementById('timer-minus-btn');
 
         // Task management
         this.tasks = [];
@@ -200,6 +202,19 @@ export class PomodoroTimer {
                 this.undoLastSession();
             }
         });
+
+        // Timer adjustment buttons
+        if (this.timerPlusBtn) {
+            this.timerPlusBtn.addEventListener('click', () => {
+                this.adjustTimer(5);
+            });
+        }
+
+        if (this.timerMinusBtn) {
+            this.timerMinusBtn.addEventListener('click', () => {
+                this.adjustTimer(-5);
+            });
+        }
 
         // Keyboard shortcuts
         document.addEventListener('keydown', async (e) => {
@@ -751,6 +766,39 @@ export class PomodoroTimer {
         if (window.tagManager) {
             window.tagManager.onTimerStop();
         }
+    }
+
+    adjustTimer(minutes) {
+        // Convert minutes to seconds
+        const adjustment = minutes * 60;
+        
+        // Add the adjustment to the current time remaining
+        this.timeRemaining += adjustment;
+        
+        // Ensure we don't go below 0 seconds
+        if (this.timeRemaining < 0) {
+            this.timeRemaining = 0;
+        }
+        
+        // If timer is running, we need to update the accuracy tracking
+        if (this.isRunning && this.timerStartTime) {
+            // Calculate how much time should remain based on the adjustment
+            const now = Date.now();
+            const elapsedSinceStart = Math.floor((now - this.timerStartTime) / 1000);
+            
+            // Update the timer duration to account for the adjustment
+            this.timerDuration = elapsedSinceStart + this.timeRemaining;
+        }
+        
+        // Update the display immediately
+        this.updateDisplay();
+        
+        // Show notification
+        const action = minutes > 0 ? 'added' : 'subtracted';
+        const absMinutes = Math.abs(minutes);
+        NotificationUtils.showNotificationPing(
+            `${absMinutes} minute${absMinutes !== 1 ? 's' : ''} ${action} ${minutes > 0 ? 'to' : 'from'} timer ⏰`
+        );
     }
 
     async skipSession() {

--- a/src/index.html
+++ b/src/index.html
@@ -95,10 +95,20 @@
 
       <!-- Status Label -->
       <div style="text-align:center; position: relative">
-        <div class="timer-status clickable" id="timer-status">
-          <i id="status-icon" class="ri-brain-line"></i>
-          <span id="status-text">Focus</span>
-          <i class="ri-arrow-down-s-line tag-dropdown-arrow" id="tag-dropdown-arrow"></i>
+        <div class="timer-status-container">
+          <button class="timer-adjust-btn" id="timer-minus-btn" title="Subtract 5 minutes">
+            <i class="ri-subtract-line"></i>
+            <span>5</span>
+          </button>
+          <div class="timer-status clickable" id="timer-status">
+            <i id="status-icon" class="ri-brain-line"></i>
+            <span id="status-text">Focus</span>
+            <i class="ri-arrow-down-s-line tag-dropdown-arrow" id="tag-dropdown-arrow"></i>
+          </div>
+          <button class="timer-adjust-btn" id="timer-plus-btn" title="Add 5 minutes">
+            <i class="ri-add-line"></i>
+            <span>5</span>
+          </button>
         </div>
         <!-- Tag Dropdown Menu -->
         <div class="tag-dropdown-menu" id="tag-dropdown-menu">

--- a/src/index.html
+++ b/src/index.html
@@ -97,8 +97,7 @@
       <div style="text-align:center; position: relative">
         <div class="timer-status-container">
           <button class="timer-adjust-btn" id="timer-minus-btn" title="Subtract 5 minutes">
-            <i class="ri-subtract-line"></i>
-            <span>5</span>
+            <span>-5</span>
           </button>
           <div class="timer-status clickable" id="timer-status">
             <i id="status-icon" class="ri-brain-line"></i>
@@ -106,8 +105,7 @@
             <i class="ri-arrow-down-s-line tag-dropdown-arrow" id="tag-dropdown-arrow"></i>
           </div>
           <button class="timer-adjust-btn" id="timer-plus-btn" title="Add 5 minutes">
-            <i class="ri-add-line"></i>
-            <span>5</span>
+            <span>+5</span>
           </button>
         </div>
         <!-- Tag Dropdown Menu -->

--- a/src/styles/timer.css
+++ b/src/styles/timer.css
@@ -6,6 +6,50 @@
   background: transparent;
 }
 
+/* Timer Status Container with Adjust Buttons */
+.timer-status-container {
+  display: flex;
+  align-items: start;
+  justify-content: center;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.timer-adjust-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--focus-timer-color);
+  padding: 0;
+}
+
+.timer-adjust-btn:hover {
+  transform: scale(1.05);
+}
+
+.timer-adjust-btn:active {
+  transform: scale(0.95);
+}
+
+.timer-adjust-btn i {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.timer-adjust-btn span {
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 /* Timer status label - positioned outside timer-container in HTML */
 #timer-view .timer-status {
   font-size: 14px;
@@ -393,6 +437,20 @@
 .container.longBreak #timer-view .timer-status {
   background-color: var(--long-break-secondary-btn);
   border: 2px solid var(--long-break-timer-color);
+  color: var(--long-break-timer-color);
+}
+
+/* Timer adjust buttons for different timer modes */
+.container.focus .timer-adjust-btn {
+  color: var(--focus-timer-color);
+}
+
+.container.break .timer-adjust-btn {
+  color: var(--break-timer-color);
+}
+
+
+.container.longBreak .timer-adjust-btn {
   color: var(--long-break-timer-color);
 }
 

--- a/src/utils/theme-loader.js
+++ b/src/utils/theme-loader.js
@@ -39,7 +39,7 @@ class ThemeLoader {
         // that gets updated by the build process or manually maintained
 
         // This could be enhanced to use a build-time script that generates this list
-                                                                                                                                                                                const knownThemes = [
+                                                                                                                                                                                        const knownThemes = [
             'espresso.css',
             'pipboy.css',
             'pommodore64.css'


### PR DESCRIPTION
This pull request introduces a new feature to the Pomodoro Timer: the ability to adjust the timer duration dynamically using "+5" and "-5" minute buttons. It includes updates to the core functionality, UI, and styling to support this feature.

### Core functionality updates:
* [`src/core/pomodoro-timer.js`](diffhunk://#diff-7bbc05e66d2a3fff640f1b3b02dd208154540f6ae6270128fc2b40831e23a98dR68-R69): Added `timerPlusBtn` and `timerMinusBtn` elements, along with event listeners for their click actions to adjust the timer by 5 minutes. Implemented a new `adjustTimer` method to handle the adjustment logic, including updating the remaining time, ensuring accuracy if the timer is running, and displaying a notification. [[1]](diffhunk://#diff-7bbc05e66d2a3fff640f1b3b02dd208154540f6ae6270128fc2b40831e23a98dR68-R69) [[2]](diffhunk://#diff-7bbc05e66d2a3fff640f1b3b02dd208154540f6ae6270128fc2b40831e23a98dR206-R218) [[3]](diffhunk://#diff-7bbc05e66d2a3fff640f1b3b02dd208154540f6ae6270128fc2b40831e23a98dR771-R803)

### UI updates:
* [`src/index.html`](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeR98-R110): Added two new buttons (`timer-minus-btn` and `timer-plus-btn`) within a `timer-status-container` for subtracting and adding 5 minutes to the timer.

### Styling updates:
* [`src/styles/timer.css`](diffhunk://#diff-9acff607891f0adad91479fda9d95ab0be130ec85b968daf64110e5711e16de1R9-R52): Introduced styles for the new timer adjustment buttons, including hover and active states, and ensured the buttons adapt to different timer modes (focus, break, long break) by changing their color dynamically. [[1]](diffhunk://#diff-9acff607891f0adad91479fda9d95ab0be130ec85b968daf64110e5711e16de1R9-R52) [[2]](diffhunk://#diff-9acff607891f0adad91479fda9d95ab0be130ec85b968daf64110e5711e16de1R443-R456)