### PR TITLE
feat: add 'Hide Icon on Close' setting and related functionality

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -302,6 +302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +521,36 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "foreign-types 0.5.0",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "libc",
+ "objc",
 ]
 
 [[package]]
@@ -2186,6 +2222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,6 +2451,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -3053,10 +3107,12 @@ version = "0.3.10"
 dependencies = [
  "base64 0.21.7",
  "chrono",
+ "cocoa",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
  "dotenv",
  "libc",
+ "objc",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,4 +51,6 @@ base64 = "0.21"
 core-graphics = "0.23"
 core-foundation = "0.9"
 libc = "0.2"
+cocoa = "0.25"
+objc = "0.2"
 

--- a/src/index.html
+++ b/src/index.html
@@ -797,6 +797,15 @@
                   start
                   minimized to the system tray.</p>
               </div>
+
+              <div class="setting-item">
+                <label class="checkbox-label">
+                  <input type="checkbox" id="hide-icon-on-close">
+                  <span class="checkmark"></span>
+                  Hide Icon on Close
+                </label>
+                <p class="setting-description">Hide the app icon from the dock when closing the window with X. The app will continue running in the system tray.</p>
+              </div>
             </div>
 
             <div class="settings-section">

--- a/src/managers/settings-manager.js
+++ b/src/managers/settings-manager.js
@@ -83,7 +83,8 @@ export class SettingsManager {
             appearance: { ...defaultSettings.appearance, ...loadedSettings.appearance },
             advanced: { ...defaultSettings.advanced, ...loadedSettings.advanced },
             autostart: loadedSettings.autostart !== undefined ? loadedSettings.autostart : defaultSettings.autostart,
-            analytics_enabled: loadedSettings.analytics_enabled !== undefined ? loadedSettings.analytics_enabled : defaultSettings.analytics_enabled
+            analytics_enabled: loadedSettings.analytics_enabled !== undefined ? loadedSettings.analytics_enabled : defaultSettings.analytics_enabled,
+            hide_icon_on_close: loadedSettings.hide_icon_on_close !== undefined ? loadedSettings.hide_icon_on_close : defaultSettings.hide_icon_on_close
         };
     }
 
@@ -118,7 +119,8 @@ export class SettingsManager {
                 debug_mode: false // Debug mode with 3-second timers
             },
             autostart: false, // default to disabled
-            analytics_enabled: true // Analytics enabled by default
+            analytics_enabled: true, // Analytics enabled by default
+            hide_icon_on_close: false // Hide icon on close disabled by default
         };
     }
 
@@ -198,6 +200,9 @@ export class SettingsManager {
 
         // Populate analytics setting
         this.loadAnalyticsSetting();
+
+        // Populate hide icon on close setting
+        this.loadHideIconOnCloseSetting();
     }
 
     setupEventListeners() {
@@ -854,6 +859,62 @@ export class SettingsManager {
 
             // Revert the checkbox state on error
             const checkbox = document.getElementById('analytics-enabled');
+            if (checkbox) {
+                checkbox.checked = !enabled;
+            }
+        }
+    }
+
+    async loadHideIconOnCloseSetting() {
+        try {
+            // Get current hide icon on close setting from our stored settings
+            const hideIconOnClose = this.settings.hide_icon_on_close;
+
+            const checkbox = document.getElementById('hide-icon-on-close');
+            if (checkbox) {
+                checkbox.checked = hideIconOnClose;
+
+                // Setup event listener for the hide icon on close checkbox
+                checkbox.addEventListener('change', async (e) => {
+                    await this.toggleHideIconOnClose(e.target.checked);
+                });
+            }
+        } catch (error) {
+            console.error('Failed to load hide icon on close setting:', error);
+            // Default to disabled if we can't check the status
+            const checkbox = document.getElementById('hide-icon-on-close');
+            if (checkbox) {
+                checkbox.checked = false;
+                checkbox.addEventListener('change', async (e) => {
+                    await this.toggleHideIconOnClose(e.target.checked);
+                });
+            }
+        }
+    }
+
+    async toggleHideIconOnClose(enabled) {
+        try {
+            // Update our settings
+            this.settings.hide_icon_on_close = enabled;
+
+            // Show user feedback
+            if (enabled) {
+                console.log('Hide icon on close enabled');
+                NotificationUtils.showNotificationPing('✓ Hide icon on close enabled - App will hide from dock when closed', 'success');
+            } else {
+                console.log('Hide icon on close disabled');
+                NotificationUtils.showNotificationPing('✓ Hide icon on close disabled - App will remain visible in dock', 'success');
+            }
+
+            // Schedule auto-save to persist the setting
+            this.scheduleAutoSave();
+
+        } catch (error) {
+            console.error('Failed to toggle hide icon on close:', error);
+            NotificationUtils.showNotificationPing('❌ Failed to toggle hide icon on close: ' + error, 'error');
+
+            // Revert the checkbox state on error
+            const checkbox = document.getElementById('hide-icon-on-close');
             if (checkbox) {
                 checkbox.checked = !enabled;
             }

--- a/src/utils/theme-loader.js
+++ b/src/utils/theme-loader.js
@@ -39,7 +39,7 @@ class ThemeLoader {
         // that gets updated by the build process or manually maintained
 
         // This could be enhanced to use a build-time script that generates this list
-                                                                                                                                                                                                                                                                                                                        const knownThemes = [
+                                                                                                                                                                                                                                                                                                                                const knownThemes = [
             'espresso.css',
             'pipboy.css',
             'pommodore64.css'


### PR DESCRIPTION
This pull request adds a new "Hide Icon on Close" feature that allows users to hide the app icon from the dock when the main window is closed, while keeping the app running in the system tray. The implementation includes both frontend UI changes and backend logic, with platform-specific support for macOS. The most important changes are grouped below.

**Feature Implementation: Hide Icon on Close**

* Added a new `hide_icon_on_close` setting to `AppSettings` and ensured it is properly handled in defaults and serialization in `src-tauri/src/lib.rs`. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR90-R91) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR179)
* Implemented logic in the window close event to hide the app icon from the dock on macOS if `hide_icon_on_close` is enabled, using the new `set_dock_visibility` command. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR1046-R1081) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR1339-R1375)
* Registered the `set_dock_visibility` command for use in the app, enabling dock visibility toggling from both backend and frontend.

**Frontend UI & Settings Management**

* Added a checkbox UI for "Hide Icon on Close" in the settings section of `src/index.html`, with a description of its behavior.
* Updated `SettingsManager` in `src/managers/settings-manager.js` to support loading, saving, and toggling the new setting, including user feedback and auto-save logic. [[1]](diffhunk://#diff-a1687f725a9d2da095d98cae1d4b8cdaf4a9eb8c14a7004f989a73746436e09bL86-R87) [[2]](diffhunk://#diff-a1687f725a9d2da095d98cae1d4b8cdaf4a9eb8c14a7004f989a73746436e09bL121-R123) [[3]](diffhunk://#diff-a1687f725a9d2da095d98cae1d4b8cdaf4a9eb8c14a7004f989a73746436e09bR203-R205) [[4]](diffhunk://#diff-a1687f725a9d2da095d98cae1d4b8cdaf4a9eb8c14a7004f989a73746436e09bR868-R923)

**Platform Support**

* Added `cocoa` and `objc` dependencies to `src-tauri/Cargo.toml` to enable macOS-specific dock visibility control.

These changes collectively provide a seamless user experience for controlling the app's dock visibility when closing the window, with robust settings management and cross-platform considerations.