### PR TITLE
feat: windows executable configuration for tauri

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   workflow_dispatch:
 
 concurrency:
@@ -18,12 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: 'macos-latest'
-            args: '--target aarch64-apple-darwin --bundles app'
-            arch: 'aarch64'
-          - platform: 'macos-latest' 
-            args: '--target x86_64-apple-darwin --bundles app'
-            arch: 'x86_64'
+          - platform: "macos-latest"
+            args: "--target aarch64-apple-darwin --bundles app"
+            arch: "aarch64"
+          - platform: "macos-latest"
+            args: "--target x86_64-apple-darwin --bundles app"
+            arch: "x86_64"
+          - platform: "windows-2025"
+            args: ""
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -33,8 +35,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
-          cache: 'npm'
+          node-version: "lts/*"
+          cache: "npm"
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -44,7 +46,7 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: './src-tauri -> target'
+          workspaces: "./src-tauri -> target"
 
       - name: Install frontend dependencies
         run: npm ci
@@ -58,7 +60,7 @@ jobs:
           TAURI_UPDATER_SUFFIX: "-${{ matrix.arch }}"
         with:
           tagName: v__VERSION__ # the action automatically replaces __VERSION__ with the app version.
-          releaseName: 'v__VERSION__'
+          releaseName: "v__VERSION__"
           releaseBody: |
             ## What's Changed
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - 'v*.*.*'
   workflow_dispatch:
 
 concurrency:
@@ -18,14 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: "macos-latest"
-            args: "--target aarch64-apple-darwin --bundles app"
-            arch: "aarch64"
-          - platform: "macos-latest"
-            args: "--target x86_64-apple-darwin --bundles app"
-            arch: "x86_64"
-          - platform: "windows-2025"
-            args: ""
+          - platform: 'macos-latest'
+            args: '--target aarch64-apple-darwin --bundles app'
+            arch: 'aarch64'
+          - platform: 'macos-latest'
+            args: '--target x86_64-apple-darwin --bundles app'
+            arch: 'x86_64'
+          - platform: 'windows-2025'
+            args: ''
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -35,8 +35,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
-          cache: "npm"
+          node-version: 'lts/*'
+          cache: 'npm'
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -46,7 +46,7 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: "./src-tauri -> target"
+          workspaces: './src-tauri -> target'
 
       - name: Install frontend dependencies
         run: npm ci
@@ -60,7 +60,7 @@ jobs:
           TAURI_UPDATER_SUFFIX: "-${{ matrix.arch }}"
         with:
           tagName: v__VERSION__ # the action automatically replaces __VERSION__ with the app version.
-          releaseName: "v__VERSION__"
+          releaseName: 'v__VERSION__'
           releaseBody: |
             ## What's Changed
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -341,7 +341,6 @@ async fn start_activity_monitoring(app: AppHandle, timeout_seconds: u64) -> Resu
         {
             monitor.start_monitoring()?;
         }
-
         #[cfg(not(target_os = "macos"))]
         {
             return Err("Activity monitoring is only supported on macOS".to_string());
@@ -1141,6 +1140,7 @@ pub fn run() {
                     let _ = app_handle.track_event("app_exited", None);
                     app_handle.flush_events_blocking();
                 }
+            
                 tauri::RunEvent::Reopen { .. } => {
                     // When the user clicks on the dock icon, show the window
                     if let Some(window) = app_handle.get_webview_window("main") {
@@ -1376,14 +1376,14 @@ async fn set_dock_visibility(app: AppHandle, visible: bool) -> Result<(), String
             set_dock_visibility_native(visible);
         })
         .map_err(|e| format!("Failed to run on main thread: {}", e))?;
+        Ok(())
     }
-
     #[cfg(not(target_os = "macos"))]
     {
-        return Err("Dock visibility is only supported on macOS".to_string());
+        let _ = app; // silence unused variable warning
+        let _ = visible; // silence unused variable warning
+        Err("Dock visibility is only supported on macOS".to_string())
     }
-
-    Ok(())
 }
 
 #[cfg(target_os = "macos")]
@@ -1440,10 +1440,11 @@ async fn set_status_bar_visibility(_app: AppHandle, visible: bool) -> Result<(),
             }
         }
     }
-
     #[cfg(not(target_os = "macos"))]
     {
-        return Err("Status bar visibility is only supported on macOS".to_string());
+        let _ = _app; // silence unused variable warning
+        let _ = visible; // silence unused variable warning
+        Err("Status bar visibility is only supported on macOS".to_string())
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1140,14 +1140,14 @@ pub fn run() {
                     let _ = app_handle.track_event("app_exited", None);
                     app_handle.flush_events_blocking();
                 }
-            
+                
+                #[cfg(target_os = "macos")]
                 tauri::RunEvent::Reopen { .. } => {
                     // When the user clicks on the dock icon, show the window
                     if let Some(window) = app_handle.get_webview_window("main") {
                         let _ = window.show();
                         let _ = window.set_focus();
                         // If the app was previously hidden from dock, restore it
-                        #[cfg(target_os = "macos")]
                         {
                             let app_handle_clone = app_handle.clone();
                             tauri::async_runtime::spawn(async move {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,9 +25,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": [
-      "app"
-    ],
+    "targets": ["app", "nsis"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
Hey, I added a config to create an executable so my colleagues with Windows can also use it. And also moved the Reopen to be scoped only for MacOS. 
I wasn't able to find specific docs about Reopen but following the release changelog https://v2.tauri.app/blog/tauri-20/ it seems that only works in MacOS.

<img width="802" height="632" alt="image" src="https://github.com/user-attachments/assets/2d41da25-74b5-45c5-95ea-993aeccd69f9" />
