### PR TITLE
39 bug menu bar item context menu is stuck in italian

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -968,19 +968,19 @@ pub fn run() {
                 });
 
                 let show_item =
-                    MenuItem::with_id(app, "show", "Mostra Presto", true, None::<&str>)?;
+                    MenuItem::with_id(app, "show", "Show Presto", true, None::<&str>)?;
                 let start_session_item = MenuItem::with_id(
                     app,
                     "start_session",
-                    "Inizia sessione",
+                    "Start Session",
                     false,
                     None::<&str>,
                 )?;
-                let pause_item = MenuItem::with_id(app, "pause", "Pausa", false, None::<&str>)?;
+                let pause_item = MenuItem::with_id(app, "pause", "Pause", false, None::<&str>)?;
                 let skip_item =
-                    MenuItem::with_id(app, "skip", "Salta sessione", false, None::<&str>)?;
-                let cancel_item = MenuItem::with_id(app, "cancel", "Annulla", false, None::<&str>)?;
-                let quit_item = MenuItem::with_id(app, "quit", "Esci", true, None::<&str>)?;
+                    MenuItem::with_id(app, "skip", "Skip Session", false, None::<&str>)?;
+                let cancel_item = MenuItem::with_id(app, "cancel", "Cancel", false, None::<&str>)?;
+                let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
                 let menu = Menu::with_items(
                     app,
                     &[
@@ -1285,43 +1285,43 @@ async fn update_tray_menu(
     let tray = app.tray_by_id("main");
 
     if let Some(tray) = tray {
-        let show_item = MenuItem::with_id(&app, "show", "Mostra Presto", true, None::<&str>)
+        let show_item = MenuItem::with_id(&app, "show", "Show Presto", true, None::<&str>)
             .map_err(|e| format!("Failed to create show item: {}", e))?;
 
-        // Inizia sessione: abilitato solo se non è in esecuzione
+        // Start Session: enabled only if not running
         let start_session_item = MenuItem::with_id(
             &app,
             "start_session",
-            "Inizia sessione",
+            "Start Session",
             !is_running,
             None::<&str>,
         )
         .map_err(|e| format!("Failed to create start session item: {}", e))?;
 
-        // Pausa: abilitata solo se è in esecuzione e non in pausa
+        // Pause: enabled only if running and not paused
         let pause_item = MenuItem::with_id(
             &app,
             "pause",
-            "Pausa",
+            "Pause",
             is_running && !is_paused,
             None::<&str>,
         )
         .map_err(|e| format!("Failed to create pause item: {}", e))?;
 
-        // Skip: abilitato solo se è in esecuzione
-        let skip_item = MenuItem::with_id(&app, "skip", "Salta sessione", is_running, None::<&str>)
+        // Skip: enabled only if running
+        let skip_item = MenuItem::with_id(&app, "skip", "Skip Session", is_running, None::<&str>)
             .map_err(|e| format!("Failed to create skip item: {}", e))?;
 
-        // Annulla: abilitato se è in modalità focus, disabilitato in break/longBreak (undo)
+        // Cancel: enabled if in focus mode, disabled in break/longBreak (undo)
         let cancel_text = if current_mode == "focus" {
-            "Annulla"
+            "Cancel"
         } else {
-            "Annulla ultima"
+            "Cancel Last"
         };
         let cancel_item = MenuItem::with_id(&app, "cancel", cancel_text, true, None::<&str>)
             .map_err(|e| format!("Failed to create cancel item: {}", e))?;
 
-        let quit_item = MenuItem::with_id(&app, "quit", "Esci", true, None::<&str>)
+        let quit_item = MenuItem::with_id(&app, "quit", "Quit", true, None::<&str>)
             .map_err(|e| format!("Failed to create quit item: {}", e))?;
 
         let new_menu = Menu::with_items(

--- a/src/index.html
+++ b/src/index.html
@@ -606,8 +606,12 @@
                   Desktop Notifications
                 </label>
                 <p class="setting-description">Show system notifications when timer completes. Browser permission will
-                  be
-                  requested when enabled.</p>
+                  be requested when enabled.<br>
+                  <strong>Note:</strong> On macOS, notifications may not work in development mode. Test with a production build for full functionality.</p>
+                <div id="notification-status" class="notification-status" style="margin-top: 8px; padding: 8px 12px; border-radius: 6px; font-size: 13px; display: none;">
+                  <span id="notification-status-text"></span>
+                  <button id="test-notifications-btn" style="margin-left: 8px; padding: 4px 8px; border: none; border-radius: 4px; font-size: 12px; cursor: pointer;">Test</button>
+                </div>
               </div>
 
               <div class="setting-item">

--- a/src/styles/notifications.css
+++ b/src/styles/notifications.css
@@ -189,3 +189,72 @@
     box-shadow: 0 3px 14px rgba(0, 0, 0, 0.09);
   }
 }
+
+/* Notification status indicator styles */
+.notification-status {
+  border-left: 3px solid #ccc;
+  background-color: var(--bg-secondary);
+  color: var(--text-secondary);
+  transition: all 0.3s ease;
+}
+
+.notification-status.status-ready {
+  border-left-color: #4CAF50;
+  background-color: rgba(76, 175, 80, 0.1);
+  color: #2E7D32;
+}
+
+.notification-status.status-warning {
+  border-left-color: #FF9800;
+  background-color: rgba(255, 152, 0, 0.1);
+  color: #E65100;
+}
+
+.notification-status.status-error {
+  border-left-color: #F44336;
+  background-color: rgba(244, 67, 54, 0.1);
+  color: #C62828;
+}
+
+.notification-status.status-disabled {
+  border-left-color: #9E9E9E;
+  background-color: rgba(158, 158, 158, 0.1);
+  color: #616161;
+}
+
+#test-notifications-btn {
+  background: var(--button-primary);
+  color: var(--button-text);
+  border: 1px solid var(--border);
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+#test-notifications-btn:hover {
+  background: var(--button-primary-hover);
+  transform: translateY(-1px);
+}
+
+#test-notifications-btn:active {
+  transform: translateY(0);
+}
+
+/* Dark theme adjustments for notification status */
+[data-theme="dark"] .notification-status.status-ready {
+  background-color: rgba(76, 175, 80, 0.15);
+  color: #81C784;
+}
+
+[data-theme="dark"] .notification-status.status-warning {
+  background-color: rgba(255, 152, 0, 0.15);
+  color: #FFB74D;
+}
+
+[data-theme="dark"] .notification-status.status-error {
+  background-color: rgba(244, 67, 54, 0.15);
+  color: #E57373;
+}
+
+[data-theme="dark"] .notification-status.status-disabled {
+  background-color: rgba(158, 158, 158, 0.15);
+  color: #BDBDBD;
+}

--- a/src/utils/theme-loader.js
+++ b/src/utils/theme-loader.js
@@ -39,7 +39,7 @@ class ThemeLoader {
         // that gets updated by the build process or manually maintained
 
         // This could be enhanced to use a build-time script that generates this list
-                                                                                                                                                                                                                                                                                                                                                                        const knownThemes = [
+                                                                                                                                                                                                                                                                                                                                                                                                                const knownThemes = [
             'espresso.css',
             'pipboy.css',
             'pommodore64.css'


### PR DESCRIPTION
This pull request introduces significant improvements to the notification system and user interface for Presto's Pomodoro timer app. The main focus is on enhancing desktop notification reliability, user feedback, and debugging capabilities across Tauri and web environments. It also standardizes menu item text to English and clarifies notification settings for users, especially regarding macOS development mode limitations.

**Notification system enhancements:**

* Major refactor of the `PomodoroTimer` class to provide a robust, multi-tiered notification system with detailed error handling, environment detection, and debug logging. This includes improved Tauri notification handling, a fallback to the Web Notification API, and a final in-app notification fallback, as well as a test utility for debugging notification issues.
* Desktop notifications are now only shown if enabled in settings, and a notification is displayed when the session time limit is reached.

**Settings and user feedback improvements:**

* The notification settings UI now always reflects the user's preference, regardless of browser/system permission, and provides immediate feedback and status messages when enabling/disabling desktop notifications. A test button and notification status display have been added to help users verify notification functionality. [[1]](diffhunk://#diff-a1687f725a9d2da095d98cae1d4b8cdaf4a9eb8c14a7004f989a73746436e09bL177-R178) [[2]](diffhunk://#diff-a1687f725a9d2da095d98cae1d4b8cdaf4a9eb8c14a7004f989a73746436e09bR599-R631) [[3]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL609-R614)

**Internationalization and UI consistency:**

* All tray menu item labels and tooltips have been translated from Italian to English for consistency and clarity in both the Rust backend (`src-tauri/src/lib.rs`) and the dynamic menu update logic. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL971-R983) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL1288-R1324)

**Documentation and user guidance:**

* The settings page now includes a clear note about macOS notification limitations in development mode and encourages users to test notifications in a production build for full functionality.

These changes collectively improve the reliability, transparency, and user experience of Presto's notification system across platforms.

**References:**  
[[1]](diffhunk://#diff-7bbc05e66d2a3fff640f1b3b02dd208154540f6ae6270128fc2b40831e23a98dL2300-R2517) [[2]](diffhunk://#diff-7bbc05e66d2a3fff640f1b3b02dd208154540f6ae6270128fc2b40831e23a98dR781-R788) [[3]](diffhunk://#diff-a1687f725a9d2da095d98cae1d4b8cdaf4a9eb8c14a7004f989a73746436e09bL177-R178) [[4]](diffhunk://#diff-a1687f725a9d2da095d98cae1d4b8cdaf4a9eb8c14a7004f989a73746436e09bR599-R631) [[5]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL609-R614) [[6]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL971-R983) [[7]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL1288-R1324)