### PR TITLE
Cfg guard code to allow build on non-macOS platforms

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -967,15 +967,9 @@ pub fn run() {
                     }
                 });
 
-                let show_item =
-                    MenuItem::with_id(app, "show", "Show Presto", true, None::<&str>)?;
-                let start_session_item = MenuItem::with_id(
-                    app,
-                    "start_session",
-                    "Start Session",
-                    false,
-                    None::<&str>,
-                )?;
+                let show_item = MenuItem::with_id(app, "show", "Show Presto", true, None::<&str>)?;
+                let start_session_item =
+                    MenuItem::with_id(app, "start_session", "Start Session", false, None::<&str>)?;
                 let pause_item = MenuItem::with_id(app, "pause", "Pause", false, None::<&str>)?;
                 let skip_item =
                     MenuItem::with_id(app, "skip", "Skip Session", false, None::<&str>)?;
@@ -1141,13 +1135,13 @@ pub fn run() {
                     let _ = app_handle.track_event("app_exited", None);
                     app_handle.flush_events_blocking();
                 }
+                #[cfg(target_os = "macos")]
                 tauri::RunEvent::Reopen { .. } => {
                     // When the user clicks on the dock icon, show the window
                     if let Some(window) = app_handle.get_webview_window("main") {
                         let _ = window.show();
                         let _ = window.set_focus();
                         // If the app was previously hidden from dock, restore it
-                        #[cfg(target_os = "macos")]
                         {
                             let app_handle_clone = app_handle.clone();
                             tauri::async_runtime::spawn(async move {


### PR DESCRIPTION
Hi, thanks for this cool project! :smile: 

I tried to build presto locally (Linux) and noticed that it does not compile as the tauri `RunEvent::Reopen` enum variant does not exist on all platforms (mainly non-macOS platforms).
Moving the config guard up to the match arm resolves the issue and allows me to also build and use presto on Linux. 

Also see https://docs.rs/tauri/latest/x86_64-apple-darwin/tauri/enum.RunEvent.html and https://docs.rs/crate/tauri/latest/target-redirect/x86_64-unknown-linux-gnu/tauri/enum.RunEvent.html.

