### PR TITLE
Fixes the showing history modal hotkey conflict on MacOS

### DIFF
--- a/src/core/pomodoro-timer.js
+++ b/src/core/pomodoro-timer.js
@@ -297,7 +297,7 @@ export class PomodoroTimer {
                             }
                             break;
                         case 'KeyH':
-                            if (e.ctrlKey || e.metaKey) {
+                            if ((e.ctrlKey || e.metaKey) && e.shiftKey) {
                                 e.preventDefault();
                                 this.showHistoryModal();
                             }


### PR DESCRIPTION
Closes #50 

The motivation is described in the linked issue. If the hotkey of choice looks bad for some reason for someone, let's discuss an alternative.

Here I replaced the hotkey `cmd/ctrl + H` for showing the history modal by `cmd/ctrl + shift + H`